### PR TITLE
Added Webhook functionality to allow/disallow publish and view events…

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,8 @@
 HTTP_ADDRESS=":8080"
 ENABLE_HTTP_REDIRECT=
 REACT_APP_API_PATH="http://localhost:8080/api"
+# WEBHOOK_URL=http://localhost:8081/webhook
+# WEBHOOK_TIMEOUT=5000
 
 # /etc/letsencrypt/live/<your-domain-name>/privkey.pem
 SSL_KEY=

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,8 @@
 HTTP_ADDRESS=":8080"
 ENABLE_HTTP_REDIRECT=
 REACT_APP_API_PATH="/api"
+# WEBHOOK_URL=http://localhost:8081/webhook
+# WEBHOOK_TIMEOUT=5000
 
 # /etc/letsencrypt/live/<your-domain-name>/privkey.pem
 SSL_KEY=

--- a/internal/webrtc/webhook.go
+++ b/internal/webrtc/webhook.go
@@ -1,0 +1,52 @@
+package webrtc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type WebhookPayload struct {
+	Action      string            `json:"action"`
+	StreamKey   string            `json:"streamKey"`
+	IP          string            `json:"ip"`
+	BearerToken string            `json:"bearerToken"`
+	QueryParams map[string]string `json:"queryParams"`
+	UserAgent   string            `json:"userAgent"`
+}
+
+func CallWebhook(url string, timeout int, payload WebhookPayload) (int, error) {
+	start := time.Now()
+	log.Printf("Starting webhook call to %s with timeout %d ms", url, timeout)
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Millisecond,
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	log.Printf("Sending webhook request...")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Webhook request failed after %v: %v", time.Since(start), err)
+		return 0, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("Received webhook response with status code %d after %v", resp.StatusCode, time.Since(start))
+
+	return resp.StatusCode, nil
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,11 @@ const (
 	networkTestIntroMessage   = "\033[0;33mNETWORK_TEST_ON_START is enabled. If the test fails Broadcast Box will exit.\nSee the README for how to debug or disable NETWORK_TEST_ON_START\033[0m"
 	networkTestSuccessMessage = "\033[0;32mNetwork Test passed.\nHave fun using Broadcast Box.\033[0m"
 	networkTestFailedMessage  = "\033[0;31mNetwork Test failed.\n%s\nPlease see the README and join Discord for help\033[0m"
+)
+
+var (
+	webhookURL     string
+	webhookTimeout int
 )
 
 var noBuildDirectoryErr = errors.New("\033[0;31mBuild directory does not exist, run `npm install` and `npm run build` in the web directory.\033[0m")
@@ -73,6 +79,14 @@ func whipHandler(res http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Prepare webhook payload
+	payload := prepareWebhookPayload("publish", streamKey, r)
+	statusCode, err := handleWebhook(payload)
+	if err != nil {
+		logHTTPError(res, err.Error(), statusCode)
+		return
+	}
+
 	offer, err := io.ReadAll(r.Body)
 	if err != nil {
 		logHTTPError(res, err.Error(), http.StatusBadRequest)
@@ -101,6 +115,14 @@ func whepHandler(res http.ResponseWriter, req *http.Request) {
 	streamKey, ok := extractBearerToken(streamKeyHeader)
 	if !ok || !validateStreamKey(streamKey) {
 		logHTTPError(res, "Invalid stream key format", http.StatusBadRequest)
+		return
+	}
+
+	// Prepare webhook payload
+	payload := prepareWebhookPayload("view", streamKey, req)
+	statusCode, err := handleWebhook(payload)
+	if err != nil {
+		logHTTPError(res, err.Error(), statusCode)
 		return
 	}
 
@@ -268,6 +290,12 @@ func main() {
 
 	}
 
+	webhookURL = os.Getenv("WEBHOOK_URL")
+	webhookTimeout, _ := strconv.Atoi(os.Getenv("WEBHOOK_TIMEOUT"))
+	if webhookTimeout == 0 {
+		webhookTimeout = 5000 // Default to 5 seconds if not set or invalid
+	}
+
 	mux := http.NewServeMux()
 	if os.Getenv("DISABLE_FRONTEND") == "" {
 		mux.Handle("/", indexHTMLWhenNotFound(http.Dir("./web/build")))
@@ -308,4 +336,49 @@ func main() {
 		log.Fatal(server.ListenAndServe())
 	}
 
+}
+
+func prepareWebhookPayload(action, streamKey string, r *http.Request) webrtc.WebhookPayload {
+	// Convert url.Values to map[string]string
+	queryParams := make(map[string]string)
+	for k, v := range r.URL.Query() {
+		if len(v) > 0 {
+			queryParams[k] = v[0]
+		}
+	}
+
+	return webrtc.WebhookPayload{
+		Action:      action,
+		StreamKey:   streamKey,
+		IP:          getIPAddress(r),
+		BearerToken: streamKey,
+		QueryParams: queryParams,
+		UserAgent:   r.UserAgent(),
+	}
+}
+
+func handleWebhook(payload webrtc.WebhookPayload) (int, error) {
+	if webhookURL == "" {
+		return http.StatusOK, nil
+	}
+
+	statusCode, err := webrtc.CallWebhook(webhookURL, webhookTimeout, payload)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Webhook call failed: %w", err)
+	}
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		return statusCode, fmt.Errorf("Webhook denied access")
+	}
+	if statusCode != http.StatusOK {
+		return statusCode, fmt.Errorf("Webhook returned unexpected status")
+	}
+	return http.StatusOK, nil
+}
+
+func getIPAddress(r *http.Request) string {
+	ip := r.Header.Get("X-Forwarded-For")
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
+	return ip
 }


### PR DESCRIPTION
Uses the following .env
WEBHOOK_URL=http://localhost:8081/webhook
WEBHOOK_TIMEOUT=5000

You need a different backend to handle webhooks
example:

mock.go
```
package main

import (
	"encoding/json"
	"flag"
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
)

type WebhookPayload struct {
	Action      string            `json:"action"`
	StreamKey   string            `json:"streamKey"`
	IP          string            `json:"ip"`
	BearerToken string            `json:"bearerToken"`
	QueryParams map[string]string `json:"queryParams"`
	UserAgent   string            `json:"userAgent"`
}

var (
	allowPublish bool
	allowView    bool
	port         int
)

func main() {
	flag.BoolVar(&allowPublish, "allow-publish", true, "Allow publish actions")
	flag.BoolVar(&allowView, "allow-view", true, "Allow view actions")
	flag.IntVar(&port, "port", 8081, "Port to run the server on")
	flag.Parse()

	http.HandleFunc("/webhook", handleWebhook)

	log.Printf("Starting webhook server on port %d", port)
	log.Printf("Allow publish: %v", allowPublish)
	log.Printf("Allow view: %v", allowView)
	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
}

type WebhookResponse struct {
	Status    string `json:"status"`
	Message   string `json:"message"`
	Action    string `json:"action"`
	StreamKey string `json:"streamKey"`
}

func handleWebhook(w http.ResponseWriter, r *http.Request) {
	if r.Method != http.MethodPost {
		sendJSONResponse(w, http.StatusMethodNotAllowed, WebhookResponse{
			Status:  "error",
			Message: "Method not allowed",
		})
		return
	}

	body, err := ioutil.ReadAll(r.Body)
	if err != nil {
		sendJSONResponse(w, http.StatusInternalServerError, WebhookResponse{
			Status:  "error",
			Message: "Error reading request body",
		})
		return
	}
	defer r.Body.Close()

	var payload WebhookPayload
	err = json.Unmarshal(body, &payload)
	if err != nil {
		sendJSONResponse(w, http.StatusBadRequest, WebhookResponse{
			Status:  "error",
			Message: "Error parsing JSON payload",
		})
		return
	}

	// Add User-Agent to the payload
	payload.UserAgent = r.UserAgent()

	// Log the incoming payload
	logPayload, _ := json.MarshalIndent(payload, "", "  ")
	log.Printf("Incoming webhook payload:\n%s", string(logPayload))

	// Check if the action is allowed
	switch payload.Action {
	case "publish":
		if !allowPublish {
			sendJSONResponse(w, http.StatusForbidden, WebhookResponse{
				Status:    "error",
				Message:   "Publish action not allowed",
				Action:    payload.Action,
				StreamKey: payload.StreamKey,
			})
			return
		}
	case "view":
		if !allowView {
			sendJSONResponse(w, http.StatusForbidden, WebhookResponse{
				Status:    "error",
				Message:   "View action not allowed",
				Action:    payload.Action,
				StreamKey: payload.StreamKey,
			})
			return
		}
	default:
		sendJSONResponse(w, http.StatusBadRequest, WebhookResponse{
			Status:    "error",
			Message:   "Unknown action",
			Action:    payload.Action,
			StreamKey: payload.StreamKey,
		})
		return
	}

	// If we get here, the action is allowed
	sendJSONResponse(w, http.StatusOK, WebhookResponse{
		Status:    "success",
		Message:   fmt.Sprintf("Action '%s' allowed for stream key '%s'", payload.Action, payload.StreamKey),
		Action:    payload.Action,
		StreamKey: payload.StreamKey,
	})
}

func sendJSONResponse(w http.ResponseWriter, statusCode int, response WebhookResponse) {
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(statusCode)
	json.NewEncoder(w).Encode(response)
}
```

Note: do not put this file with broadcast-box folder, as it uses same function name, compile it somewhere else.